### PR TITLE
Add engines field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,6 @@
   },
   "bugs": {
     "url": "https://github.com/crabdude/babel-node-debug/issues"
-  }
+  },
+  "engines" : { "node" : "<7.0" }
 }


### PR DESCRIPTION
v8-debug (a transitive dependency) doesn't work on node 7. See https://github.com/node-inspector/v8-debug/issues/32